### PR TITLE
Feat: Implement "Can Place Flowers" solution

### DIFF
--- a/app/src/main/java/com/faridnia/myapplication/leetCode/can_place_flowers_605/CanPlaceFlowers.kt
+++ b/app/src/main/java/com/faridnia/myapplication/leetCode/can_place_flowers_605/CanPlaceFlowers.kt
@@ -1,0 +1,45 @@
+package com.faridnia.myapplication.leetCode.can_place_flowers_605
+
+/**
+You have a long flowerbed in which some of the plots are planted, and some are not. However, flowers cannot be planted in adjacent plots.
+
+Given an integer array flowerbed containing 0's and 1's, where 0 means empty and 1 means not empty, and an integer n, return true if n new flowers can be planted in the flowerbed without violating the no-adjacent-flowers rule and false otherwise.
+
+Example 1:
+
+Input: flowerbed = [1,0,0,0,1], n = 1
+Output: true
+Example 2:
+
+Input: flowerbed = [1,0,0,0,1], n = 2
+Output: false
+
+
+Constraints:
+
+1 <= flowerbed.length <= 2 * 104
+flowerbed[i] is 0 or 1.
+There are no two adjacent flowers in flowerbed.
+0 <= n <= flowerbed.length
+ */
+
+class Solution {
+    fun canPlaceFlowers(flowerbed: IntArray, n: Int): Boolean {
+        var availablePlacesCount = 0
+
+        flowerbed.forEachIndexed { index, value ->
+            if (value == 0) {
+                val emptyLeft = (index == 0) || (flowerbed[index - 1] == 0)
+                val emptyRight = (index == flowerbed.lastIndex) || (flowerbed[index + 1] == 0)
+
+                if (emptyLeft && emptyRight) {
+                    flowerbed[index] = 1
+                    availablePlacesCount++
+                    if (availablePlacesCount >= n) return true
+                }
+            }
+        }
+
+        return availablePlacesCount >= n
+    }
+}


### PR DESCRIPTION
This commit introduces a solution to the LeetCode problem "Can Place Flowers".

The `canPlaceFlowers` function determines if `n` new flowers can be planted in a `flowerbed` without violating the no-adjacent-flowers rule.

- It iterates through the `flowerbed`.
- For each empty plot (value 0):
    - It checks if the left adjacent plot is empty or if it's the first plot.
    - It checks if the right adjacent plot is empty or if it's the last plot.
    - If both adjacent plots (or boundaries) are empty, it "plants" a flower (sets the plot to 1) and increments `availablePlacesCount`.
    - If `availablePlacesCount` reaches `n`, it immediately returns `true`.
- After iterating through the entire `flowerbed`, it returns `true` if `availablePlacesCount` is greater than or equal to `n`, and `false` otherwise.